### PR TITLE
Write severity filed in resulting json file

### DIFF
--- a/src/main/kotlin/ru/mobileup/codequality/input/DetektParser.kt
+++ b/src/main/kotlin/ru/mobileup/codequality/input/DetektParser.kt
@@ -31,8 +31,8 @@ class DetektParser {
     }
 
     private fun String?.toSeverity(): Severity = when (this) {
-        "error" -> Severity.ERROR
-        "warning" -> Severity.WARNING
-        else -> Severity.INFORMATION
+        "error" -> Severity.BLOCKER
+        "warning" -> Severity.CRITICAL
+        else -> Severity.INFO
     }
 }

--- a/src/main/kotlin/ru/mobileup/codequality/input/LintParser.kt
+++ b/src/main/kotlin/ru/mobileup/codequality/input/LintParser.kt
@@ -29,8 +29,8 @@ class LintParser {
     }
 
     private fun String?.toSeverity(): Severity = when (this) {
-        "Error" -> Severity.ERROR
-        "Warning" -> Severity.WARNING
-        else -> Severity.INFORMATION
+        "Error" -> Severity.BLOCKER
+        "Warning" -> Severity.CRITICAL
+        else -> Severity.INFO
     }
 }

--- a/src/main/kotlin/ru/mobileup/codequality/issueconverter/Issue.kt
+++ b/src/main/kotlin/ru/mobileup/codequality/issueconverter/Issue.kt
@@ -7,6 +7,10 @@ data class Issue(
     val line: Int
 )
 
-enum class Severity {
-    INFORMATION, WARNING, ERROR
+enum class Severity(val severityName: String) {
+    INFO("info"),
+    MINOR("minor"),
+    MAJOR("major"),
+    CRITICAL("critical"),
+    BLOCKER("blocker")
 }

--- a/src/main/kotlin/ru/mobileup/codequality/output/IssuesWriter.kt
+++ b/src/main/kotlin/ru/mobileup/codequality/output/IssuesWriter.kt
@@ -9,6 +9,7 @@ import java.security.MessageDigest
 private class IssueJson(
     val description: String,
     val fingerprint: String,
+    val severity: String,
     val location: LocationJson
 )
 
@@ -28,6 +29,7 @@ class IssuesWriter {
             IssueJson(
                 description = issue.description,
                 fingerprint = calculateFingerprint(issue),
+                severity = issue.severity.severityName,
                 location = LocationJson(
                     path = getRelativePath(issue.filePath, outputFile.parentFile.absolutePath),
                     lines = LinesJson(begin = issue.line)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31704485/112804375-08ed1900-907d-11eb-8420-b11ccf39de89.png)

Due to the fact that there was no severity field in the json file, the error level in the Code quality widget in Git lab is not displayed.